### PR TITLE
Merging exclude options array

### DIFF
--- a/test/actual/image-files.json
+++ b/test/actual/image-files.json
@@ -6,16 +6,6 @@
     "type": "git",
     "url": "git://github.com/assemble/assemble-manifest.git"
   },
-  "devDependencies": {
-    "grunt": "~0.4.1",
-    "grunt-contrib-clean": "~0.4.1",
-    "grunt-contrib-jshint": "~0.4.3",
-    "grunt-contrib-nodeunit": "~0.1.2",
-    "json2yaml": "~1.0.1",
-    "js-yaml": "~2.0.4",
-    "lodash": "~1.1.1",
-    "mout": "~0.5.0"
-  },
   "peerDependencies": {
     "grunt": "~0.4.1"
   },

--- a/test/actual/less.json
+++ b/test/actual/less.json
@@ -6,27 +6,6 @@
     "type": "git",
     "url": "git://github.com/assemble/assemble-manifest.git"
   },
-  "dependencies": {
-    "amdefine": "0.0.4",
-    "chai": "~1.5.0",
-    "grunt": "~0.4.0",
-    "grunt-contrib-jshint": "~0.1.0",
-    "grunt-contrib-watch": "~0.2.0",
-    "grunt-mocha-test": "~0.2.0",
-    "grunt-release": "~0.2.0",
-    "handlebars": "~1.0.9",
-    "testem": "~0.2.68"
-  },
-  "devDependencies": {
-    "grunt": "~0.4.1",
-    "grunt-contrib-clean": "~0.4.1",
-    "grunt-contrib-jshint": "~0.4.3",
-    "grunt-contrib-nodeunit": "~0.1.2",
-    "json2yaml": "~1.0.1",
-    "js-yaml": "~2.0.4",
-    "lodash": "~1.1.1",
-    "mout": "~0.5.0"
-  },
   "peerDependencies": {
     "grunt": "~0.4.1"
   },


### PR DESCRIPTION
Adding method to merge task and target options arrays together.
Merging the exclude options arrays so all exclude properties will be excluded.
Moving the utility function declarations outside of the registerMultiTask call.
